### PR TITLE
Update tea minus countdown

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -47,14 +47,6 @@
 </main>
 
 <section class="links">
-    <a href="brew4europe.ics">
-        <!-- octicons calendar.svg -->
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 16">
-            <path fill-rule="evenodd" d="M13 2h-1v1.5c0 .28-.22.5-.5.5h-2c-.28 0-.5-.22-.5-.5V2H6v1.5c0 .28-.22.5-.5.5h-2c-.28 0-.5-.22-.5-.5V2H2c-.55 0-1 .45-1 1v11c0 .55.45 1 1 1h11c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm0 12H2V5h11v9zM5 3H4V1h1v2zm6 0h-1V1h1v2zM6 7H5V6h1v1zm2 0H7V6h1v1zm2 0H9V6h1v1zm2 0h-1V6h1v1zM4 9H3V8h1v1zm2 0H5V8h1v1zm2 0H7V8h1v1zm2 0H9V8h1v1zm2 0h-1V8h1v1zm-8 2H3v-1h1v1zm2 0H5v-1h1v1zm2 0H7v-1h1v1zm2 0H9v-1h1v1zm2 0h-1v-1h1v1zm-8 2H3v-1h1v1zm2 0H5v-1h1v1zm2 0H7v-1h1v1zm2 0H9v-1h1v1z"/>
-        </svg>
-        Add brews to your calendar
-    </a>
-
     <a href="tm/index.html">
         <!-- octicons alert.svg -->
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">

--- a/public/scripts/tm.js
+++ b/public/scripts/tm.js
@@ -39,7 +39,7 @@ function getBrewsRemaining(startTime, endTime) {
 }
 
 function initializeCountdown() {
-    var endtime = new Date('October 31, 2019 23:00:00 GMT');
+    var endtime = new Date('January 31, 2020 23:00:00 GMT');
 
     var clock = document.getElementById('tmClock');
     var daysSpan = clock.querySelector('.days');


### PR DESCRIPTION
The UK is now due to leave on 31st January 2020 unless something changes

Note: assume that the time of departure is still 11pm UK time

Also removes out of date .ics link

Signed-off-by: James Taylor <jt-git@nti.me.uk>